### PR TITLE
docs: update changelog for v1.20.0

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -4,6 +4,19 @@ description: 'Latest updates and improvements to mkbrr'
 icon: code-merge
 ---
 
+<Update label="v1.20.0" description="2026-01-26">
+### New Features
+- [2528c79](https://github.com/autobrr/mkbrr/commit/2528c79d20457df94e02a713f4a8251592758954): Add homebrew formula generation to goreleaser ([#135](https://github.com/autobrr/mkbrr/pull/135)) (@s0up4200)
+
+### Bug fixes
+- [dc7cb4c](https://github.com/autobrr/mkbrr/commit/dc7cb4c3ce0b76c9c64190221ce6ef2d9bb0d6ba): Use HOMEBREW_TAP_GITHUB_TOKEN for tap access (@s0up4200)
+- [e37bab6](https://github.com/autobrr/mkbrr/commit/e37bab634faa07106a24e1e29e8d995804de7d14): Pass HOMEBREW_TAP_GITHUB_TOKEN to goreleaser (@s0up4200)
+
+**Full Changelog**: [v1.19.0...v1.20.0](https://github.com/autobrr/mkbrr/compare/v1.19.0...v1.20.0)
+
+### Contributors
+- @s0up4200
+</Update>
 <Update label="v1.19.0" description="2026-01-14">
 ### New Features
 - [577f795](https://github.com/autobrr/mkbrr/commit/577f795867616b0230224cdc3499c2f562b3acd7): Show magnet link in inspect output ([#120](https://github.com/autobrr/mkbrr/pull/120)) (@IonBazan)


### PR DESCRIPTION
This PR updates the changelog with the latest release information from [v1.20.0](https://github.com/autobrr/mkbrr/releases/tag/v1.20.0).