### PR TITLE
docs: update Aither and TorrentLeech tracker rules

### DIFF
--- a/features/tracker-rules.mdx
+++ b/features/tracker-rules.mdx
@@ -55,9 +55,9 @@ The tracker rules are maintained in the [mkbrr source code](https://github.com/a
 | TSYNDIKAT | Custom | 16 MiB | - | - |
 | OE | Custom | 16 MiB | - | - |
 | lst.gg | Custom | 16 MiB | - | lst.gg |
-| Aither | Default | - | - | Aither |
+| Aither | Custom | 128 MiB | - | Aither |
 | ULCX | Default | - | - | ULCX |
 | CapybaraBR | Default | - | - | CapybaraBR |
 | HUNO | Default | - | - | HUNO |
-| TorrentLeech | Custom | 16 MiB | - | TorrentLeech.org |
+| TorrentLeech | Custom | 128 MiB | - | TorrentLeech.org |
 


### PR DESCRIPTION
Updates tracker rules table to reflect changes from autobrr/mkbrr#162 and autobrr/mkbrr#161. Aither now has custom piece size ranges with a 128 MiB max, and TorrentLeech's max piece size increased from 16 MiB to 128 MiB with additional ranges for larger content.

Syncs docs with upcoming mkbrr v1.22.0.